### PR TITLE
bug: fix active window subscription on macOS and add selfListenOption

### DIFF
--- a/components/src/Preferences.svelte
+++ b/components/src/Preferences.svelte
@@ -19,6 +19,7 @@
   let useRegEx = false;
   let defaultPageNumber = "-1";
   let listenOption = "name";
+  let listenToSelf = false;
 
   let hasBeenInitialized = false;
 
@@ -30,6 +31,7 @@
     useRegEx,
     listenOption,
     defaultPageNumber,
+    listenToSelf,
     updateConfiguration();
 
   // @ts-ignore
@@ -45,6 +47,7 @@
         defaultPageNumber = String(data.defaultPage);
         activeWindow = String(data.lastPageActivator);
         listenOption = data.listenOption;
+        listenToSelf = data.listenToSelf;
       } else if (data.type === "active-info") {
         activeWindow = data.active;
       }
@@ -79,7 +82,8 @@
       pageActivators,
       useRegEx,
       defaultPage: Number(defaultPageNumber),
-      listenOption: listenOption,
+      listenOption,
+      listenToSelf
     });
   }
 </script>
@@ -126,6 +130,11 @@
         <MeltCheckbox
           title={"Use Regular Expressions"}
           bind:target={useRegEx}
+          style="none"
+        />
+        <MeltCheckbox
+          title={"Listen to Editor focus for Active window info"}
+          bind:target={listenToSelf}
           style="none"
         />
         <MeltCombo

--- a/index.js
+++ b/index.js
@@ -141,7 +141,13 @@ async function checkActiveWindow(result) {
     }
 
     // When the active window is the editor itself, we don't want to send the active-info message to the editor
-    if (listenToSelf === false && title.includes("Editor")) {
+    console.log({ title, targetString });
+    if (
+      listenToSelf === false &&
+      (title.includes("Grid Editor") ||
+        title.includes("Electron") ||
+        title == "Editor")
+    ) {
       return;
     }
 

--- a/index.js
+++ b/index.js
@@ -18,7 +18,7 @@ exports.loadPackage = async function (gridController, persistedData) {
   listenOption = persistedData?.listenOption ?? "name";
   listenToSelf = persistedData?.listenToSelf ?? false;
 
-  ActiveWindow.initialize({osxRunLoop: 'all'});
+  ActiveWindow.initialize({ osxRunLoop: "all" });
 
   isEnabled = true;
 
@@ -75,7 +75,7 @@ async function onMessage(port, data) {
       useRegEx,
       defaultPage,
       listenOption,
-      listenToSelf
+      listenToSelf,
     };
 
     controller.sendMessageToEditor({
@@ -89,7 +89,6 @@ async function onMessage(port, data) {
 
 async function checkActiveWindow(result) {
   try {
-    
     if (result === undefined) {
       result = { owner: { name: "Unknown!" }, title: "Invalid title!" };
     }
@@ -142,7 +141,7 @@ async function checkActiveWindow(result) {
     }
 
     // When the active window is the editor itself, we don't want to send the active-info message to the editor
-    if(listenToSelf === false && title.includes("Editor")){
+    if (listenToSelf === false && title.includes("Editor")) {
       return;
     }
 
@@ -152,7 +151,6 @@ async function checkActiveWindow(result) {
         active: targetString,
       });
     }
-
   } catch (e) {
     console.error("error:", e);
     controller.sendMessageToEditor({

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "package-active-win",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "package-active-win",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "hasInstallScript": true,
       "license": "ISC",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "package-active-win",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Active Window",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
### Issue I.
Active window did not work on macOS, it only emitted the active window upon starting the package.
The issue was a missing initialization, with osx related init option.

From the node-active-window docs:

> On some platforms (Linux) the library needs some initialization to be done. You must call this function before doing anything with the library regardless of the current platform.
Possible values for `osxRunLoop`:
> - `false` or not set (default): Don't run the run loop manually.
> - `get`: Run the run loop only for the getActiveWindow calls. Subscriptions will not work with this mode.
> - `all`: Run the run loop both for getActiveWindow calls and for subscriptions.

### Issue II.
When clicking the Editor, then the active window info text gets overwritten with Editor itself. This is counterproductive when there is the **Apply** button. 

Added the option to "Listen to Editor focus for Active window info", which is disabled (false) by default.

This does not disable the page change message activated when one of the page changes are Editor.

### Test

- [ ] should check on windows
- [ ] should check on linux
- [ ] should be checked on macos
